### PR TITLE
Let user mark some objects as local-only or remote-only:

### DIFF
--- a/Assets/Settings/ContentPoliceSelector.asset
+++ b/Assets/Settings/ContentPoliceSelector.asset
@@ -152,3 +152,4 @@ MonoBehaviour:
   - UnityEngine.Transform
   - UnityEngine.Animator
   - UnityEngine.SkinnedMeshRenderer
+  - Basis.Scripts.BasisSdk.BasisConditionalLoad

--- a/Packages/basisdk/Scripts/BasisConditionalLoad.cs
+++ b/Packages/basisdk/Scripts/BasisConditionalLoad.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using UnityEngine;
+using UnityEngine.Serialization;
+
+namespace Basis.Scripts.BasisSdk
+{
+    [DisallowMultipleComponent]
+    public class BasisConditionalLoad : MonoBehaviour
+    {
+        public bool useNetworkCondition = true;
+        public BasisConditionalLoadNetwork networkAllow = BasisConditionalLoadNetwork.Local;
+    }
+
+    [Flags]
+    public enum BasisConditionalLoadNetwork
+    {
+        Local = 1,
+        Remote = 2
+    }
+}

--- a/Packages/basisdk/Scripts/BasisConditionalLoad.cs.meta
+++ b/Packages/basisdk/Scripts/BasisConditionalLoad.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: a846e95468324a2eb87cbcb5f727b73b
+timeCreated: 1733917839


### PR DESCRIPTION
- Let the user mark that some objects should only exist local-only, or remote-only.
- This lets the user choose to destroy some objects like cameras, displays, local triggers, and such.
- Such objects are subject to the same content policing restrictions even if they are local-only, so that the eventual possibility of borrowing avatars would not execute possibly unsafe components to other wearers.
- Add Basis.Scripts.BasisSdk.BasisConditionalLoad to the default content police selector.