### PR TITLE
Make NDMF create an Addressable prefab when entering Play Mode:

### DIFF
--- a/Packages/HVRBasisNDMF/Scripts/Editor/BasisNDMFCreateTestAvatarPlugin.cs
+++ b/Packages/HVRBasisNDMF/Scripts/Editor/BasisNDMFCreateTestAvatarPlugin.cs
@@ -1,0 +1,85 @@
+﻿#if BASISNDMF_NDMF_IS_INSTALLED
+using Basis.Scripts.BasisSdk;
+using HVR.Basis.NDMF;
+using nadena.dev.ndmf;
+using UnityEditor;
+using UnityEditor.AddressableAssets;
+using UnityEngine;
+
+[assembly: ExportsPlugin(typeof(BasisNDMFCreateTestAvatarPlugin))]
+namespace HVR.Basis.NDMF
+{
+    public class BasisNDMFCreateTestAvatarPlugin : Plugin<BasisNDMFCreateTestAvatarPlugin>
+    {
+        private const string NameOfAddressableForTestAvatar = "TestLocalAvatar";
+        private const string TestLocalAvatarPrefabLocation = "Assets/TestLocalAvatar.prefab";
+        public override string QualifiedName => "HVR.Basis.NDMF.BasisNDMFCreateTestAvatarPlugin";
+
+        protected override void Configure()
+        {
+            InPhase(BuildPhase.Optimizing)
+                .AfterPlugin("nadena.dev.modular-avatar")
+                .AfterPlugin("nadena.dev.ndmf.InternalPasses")
+                .Run("Basis NDMF: Make Addressable if Play Mode", MakeAddressableIfPlayMode);
+        }
+
+        private void MakeAddressableIfPlayMode(BuildContext context)
+        {
+            if (!Application.isPlaying) return;
+            if (!context.AvatarRootObject.GetComponent<BasisAvatar>()) return;
+
+            var asset = AssetDatabase.LoadAssetAtPath<Object>(TestLocalAvatarPrefabLocation);
+            if (asset)
+            {
+                Object.Destroy(asset);
+            }
+
+            var completedAvatar = context.AvatarRootObject;
+            
+            // We need to create the addressable prefab only after the NDMF BuildContext finishes,
+            // because the prefab needs to reference serialized assets.
+            // NDMF does not support post-processors that run after the serialization of the avatar,
+            // so we're delaying the call as a hack.
+            EditorApplication.delayCall += () =>
+            {
+                if (!Application.isPlaying) return;
+                
+                StoreAvatarAsAddressable(completedAvatar);
+            };
+        }
+
+        private static void StoreAvatarAsAddressable(GameObject completedAvatar)
+        {
+            // We don't want the AvatarActivator to trigger again when copying the avatar.
+            completedAvatar.SetActive(false);
+            var copy = Object.Instantiate(completedAvatar);
+            
+            try
+            {
+                var monoBehaviours = copy.GetComponents<MonoBehaviour>();
+                foreach (var monoBehaviour in monoBehaviours)
+                {
+                    if (monoBehaviour && monoBehaviour.GetType().FullName == "nadena.dev.ndmf.runtime.AvatarActivator")
+                    {
+                        Object.Destroy(monoBehaviour);
+                    }
+                }
+
+                var prefab = PrefabUtility.SaveAsPrefabAsset(copy, TestLocalAvatarPrefabLocation);
+                
+                var addressableSettings = AddressableAssetSettingsDefaultObject.Settings;
+                var guid = AssetDatabase.AssetPathToGUID(AssetDatabase.GetAssetPath(prefab));
+                addressableSettings.CreateAssetReference(guid);
+                var addressableAsset = addressableSettings.FindAssetEntry(guid);
+                addressableAsset.address = NameOfAddressableForTestAvatar;
+            }
+            finally
+            {
+                Object.Destroy(copy);
+            }
+            
+            completedAvatar.SetActive(true);
+        }
+    }
+}
+#endif

--- a/Packages/HVRBasisNDMF/Scripts/Editor/BasisNDMFCreateTestAvatarPlugin.cs.meta
+++ b/Packages/HVRBasisNDMF/Scripts/Editor/BasisNDMFCreateTestAvatarPlugin.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: b8df5943ad4d4374b4e6c5720a2d33ca
+timeCreated: 1733945872

--- a/Packages/HVRBasisNDMF/Scripts/HVR.Basis.NDMF.asmdef
+++ b/Packages/HVRBasisNDMF/Scripts/HVR.Basis.NDMF.asmdef
@@ -3,7 +3,10 @@
     "rootNamespace": "",
     "references": [
         "nadena.dev.ndmf",
-        "BasisSDKEditor"
+        "BasisSDKEditor",
+        "Unity.Addressables",
+        "Unity.Addressables.Editor",
+        "BasisSDK"
     ],
     "includePlatforms": [
         "Editor"


### PR DESCRIPTION
- If we use NDMF, entering Play Mode is not sufficient to equip the avatar for local testing.
- We need to create an Addressable prefab out of the avatar, but only after the avatar has been serialized by NDMF, otherwise we'll get missing references.
- NDMF serializes the avatar only when the build context "finishes", which is after all NDMF passes are completed.
- To hack around this, create a NDMF plugin that runs at the end of the Optimizing phase, which will delay an invocation later which will turn the processed and serialized avatar into an Addressable prefab.
- Only one avatar per scene is supported.