### PR TITLE
Work towards adding Toggles, and Face Tracking fixes:

### DIFF
--- a/Packages/HVRBasisAvatarComms/Scripts/Acquisition/AcquisitionAssist.cs
+++ b/Packages/HVRBasisAvatarComms/Scripts/Acquisition/AcquisitionAssist.cs
@@ -11,6 +11,8 @@ namespace HVR.Basis.Comms
         [HideInInspector] public AcquisitionService acquisitionService;
         [NonSerialized] public Dictionary<string, float> memory = new Dictionary<string, float>();
 
+        public string[] toggles;
+
         private void Awake()
         {
             if (acquisitionService == null) acquisitionService = AcquisitionService.SceneInstance;

--- a/Packages/HVRBasisAvatarComms/Scripts/Actuation/BlendshapeActuation.cs
+++ b/Packages/HVRBasisAvatarComms/Scripts/Actuation/BlendshapeActuation.cs
@@ -23,15 +23,30 @@ namespace HVR.Basis.Comms
         private Dictionary<string, int> _addressBase = new Dictionary<string, int>();
         private ComputedActuator[] _computedActuators;
         private ComputedActuator[][] _addressBaseIndexToActuators;
-        private FeatureInterpolator featureInterpolator;
+        
+#region NetworkingFields
         private int _guidIndex;
-        private bool _isNetworkable;
+        // Can be null due to:
+        // - Application with no network, or
+        // - Network late initialization.
+        // Nullability is needed for local tests without initialization scene.
+        // - Becomes non-null after HVRAvatarComms.OnAvatarNetworkReady is successfully invoked
+        private FeatureInterpolator _featureInterpolator;
+        private bool _avatarReady;
+        private bool _networkReady;
+        private bool _dualInitialized;
+
+        #endregion
 
         private void Awake()
         {
             if (avatar == null) avatar = CommsUtil.GetAvatar(this);
             if (featureNetworking == null) featureNetworking = CommsUtil.FeatureNetworkingFromAvatar(avatar);
             if (acquisition == null) acquisition = AcquisitionService.SceneInstance;
+            
+            renderers = CommsUtil.SlowSanitizeEndUserProvidedObjectArray(renderers);
+            definitionFiles = CommsUtil.SlowSanitizeEndUserProvidedObjectArray(definitionFiles);
+            definitions = CommsUtil.SlowSanitizeEndUserProvidedStructArray(definitions);
 
             avatar.OnAvatarReady -= OnAvatarReady;
             avatar.OnAvatarReady += OnAvatarReady;
@@ -55,11 +70,10 @@ namespace HVR.Basis.Comms
                 upper = actuator.StreamedUpper;
             }
             
-            var streamed01 = Mathf.InverseLerp(lower, upper, inRange);
-
-            if (featureInterpolator != null) // Can be null due to network late init, this is needed for local tests without initialization scene 
+            if (_featureInterpolator != null)
             {
-                featureInterpolator.Store(index, streamed01);
+                var streamed01 = Mathf.InverseLerp(lower, upper, inRange);
+                _featureInterpolator.Store(index, streamed01);
             }
         }
 
@@ -149,7 +163,13 @@ namespace HVR.Basis.Comms
                         StreamedUpper = upper,
                         UseCurve = definition.useCurve,
                         Curve = definition.curve,
-                        Targets = actuatorTargets
+                        Targets = actuatorTargets,
+                        RequestedFeature = new RequestedFeature
+                        {
+                            identifier = definition.address,
+                            lower = lower,
+                            upper = upper
+                        }
                     };
                 })
                 .Where(actuator => actuator != null)
@@ -160,16 +180,41 @@ namespace HVR.Basis.Comms
             {
                 _addressBaseIndexToActuators[computedActuator.Key] = computedActuator.ToArray();
             }
+            
+            if (isWearer)
+            {
+                acquisition.RegisterAddresses(_addressBase.Keys.ToArray(), OnAddressUpdated);
+            }
 
-            acquisition.RegisterAddresses(_addressBase.Keys.ToArray(), OnAddressUpdated);
-            _isNetworkable = true;
+            _avatarReady = true;
+            TryOnAvatarIsNetworkable();
         }
 
-        private void WhenNetworkIdAssigned()
+        public void OnGuidAssigned(int guidIndex, Guid guid)
         {
-            if (!_isNetworkable) return;
+            _guidIndex = guidIndex;
+            
+            _networkReady = true;
+            TryOnAvatarIsNetworkable();
+        }
 
-            featureInterpolator = featureNetworking.NewInterpolator(_guidIndex, _addressBase.Count, OnInterpolatedDataChanged);
+        private void TryOnAvatarIsNetworkable()
+        {
+            // HACK: Work around an issue where remote and local avatars trigger
+            // OnAvatarReady and OnAvatarNetworkReady in a different order.
+
+            if (_avatarReady && _networkReady && !_dualInitialized)
+            {
+                _dualInitialized = true;
+                OnAvatarFullyNetworkable();
+            }
+        }
+
+        private void OnAvatarFullyNetworkable()
+        {
+            // FIXME: We should be using the computed actuators instead of the address base, assuming that
+            // the list of blendshapes is the same local and remote (no local-only or remote-only blendshapes).
+            _featureInterpolator = featureNetworking.NewInterpolator(_guidIndex, _addressBase.Count, OnInterpolatedDataChanged);
         }
 
         private Dictionary<string, int> MakeIndexDictionary(string[] addressBase)
@@ -196,10 +241,10 @@ namespace HVR.Basis.Comms
         {
             acquisition.UnregisterAddresses(_addressBase.Keys.ToArray(), OnAddressUpdated);
 
-            if (featureInterpolator != null)
+            if (_featureInterpolator != null)
             {
-                featureInterpolator.Unregister();
-                featureInterpolator = null;
+                _featureInterpolator.Unregister();
+                _featureInterpolator = null;
             }
         }
 
@@ -266,18 +311,13 @@ namespace HVR.Basis.Comms
             public bool UseCurve;
             public AnimationCurve Curve;
             public ComputedActuatorTarget[] Targets;
+            public RequestedFeature RequestedFeature;
         }
 
         private class ComputedActuatorTarget
         {
             public SkinnedMeshRenderer Renderer;
             public int[] BlendshapeIndices;
-        }
-
-        public void OnGuidAssigned(int guidIndex, Guid guid)
-        {
-            _guidIndex = guidIndex;
-            WhenNetworkIdAssigned();
         }
     }
 }

--- a/Packages/HVRBasisAvatarComms/Scripts/Actuation/ObjectStateActuation.cs
+++ b/Packages/HVRBasisAvatarComms/Scripts/Actuation/ObjectStateActuation.cs
@@ -1,0 +1,218 @@
+﻿using System;
+using System.Collections;
+using Basis.Scripts.BasisSdk;
+using UnityEngine;
+
+namespace HVR.Basis.Comms
+{
+    [AddComponentMenu("HVR.Basis/Comms/Object State Actuation")]
+    public class ObjectStateActuation : MonoBehaviour, ICommsNetworkable
+    {
+        public ActivationSource activationSource;
+        public string address;
+        
+        [SerializeField] private bool isActiveByDefault;
+        [SerializeField] private bool isInterpolated;
+        [SerializeField] private float interpolationToActiveDuration = 0f;
+        [SerializeField] private float interpolationToInactiveDuration = 0f;
+        
+        [SerializeField] private Component[] whenActive;
+        [SerializeField] private Component[] whenInactive;
+
+        private bool _currentTargetState;
+        private InterpolatingState _currentInterpolation;
+        
+        private float _lastStateChangeTime = 0f;
+        private float _endStateChangeTime = 0f;
+        private Coroutine _lastCoroutineNullable;
+        
+        [HideInInspector] [SerializeField] private BasisAvatar avatar;
+        [HideInInspector] [SerializeField] private FeatureNetworking featureNetworking;
+        [HideInInspector] [SerializeField] private AcquisitionService acquisition;
+        
+#region NetworkingFields
+        private int _guidIndex;
+        // Can be null due to:
+        // - Application with no network, or
+        // - Network late initialization.
+        // Nullability is needed for local tests without initialization scene.
+        // - Becomes non-null after HVRAvatarComms.OnAvatarNetworkReady is successfully invoked
+        private FeatureEvent _featureEvent;
+        private byte[] _msg;
+        private bool _isWearer;
+#endregion
+
+        private void Awake()
+        {
+            if (avatar == null) avatar = CommsUtil.GetAvatar(this);
+            if (featureNetworking == null) featureNetworking = CommsUtil.FeatureNetworkingFromAvatar(avatar);
+            if (acquisition == null) acquisition = AcquisitionService.SceneInstance;
+
+            whenActive = CommsUtil.SlowSanitizeEndUserProvidedObjectArray(whenActive);
+            whenInactive = CommsUtil.SlowSanitizeEndUserProvidedObjectArray(whenInactive);
+
+            if (!isInterpolated)
+            {
+                interpolationToActiveDuration = 0f;
+                interpolationToInactiveDuration = 0f;
+            }
+
+            avatar.OnAvatarReady -= OnAvatarReady;
+            avatar.OnAvatarReady += OnAvatarReady;
+            
+            _msg = new byte[1];
+        }
+
+        private void OnAvatarReady(bool isWearer)
+        {
+            _isWearer = isWearer;
+            
+            _currentTargetState = isActiveByDefault;
+            _currentInterpolation = isActiveByDefault ? InterpolatingState.Active : InterpolatingState.Inactive;
+
+            if (isWearer)
+            {
+                acquisition.RegisterAddresses(new []{ address }, OnAddressUpdated);
+            }
+
+            ForceUpdateState();
+        }
+
+        private void OnDestroy()
+        {
+            if (_isWearer)
+            {
+                acquisition.UnregisterAddresses(new []{ address }, OnAddressUpdated);
+            }
+        }
+
+        private void ForceUpdateState()
+        {
+            Debug.Log($"Target is {_currentTargetState} and interpolation is {_currentInterpolation}");
+            // When _currentState is Interpolating, both Active and Inactive objects are visible.
+            // This is to enable interpolation effects such as material fading or material dissolving.
+            
+            var activeObjectsShouldBecome = _currentInterpolation != InterpolatingState.Inactive;
+            foreach (var component in whenActive)
+            {
+                ProcessObject(component, activeObjectsShouldBecome);
+            }
+            
+            var inactiveObjectsShouldBecome = _currentInterpolation != InterpolatingState.Active;
+            foreach (var component in whenInactive)
+            {
+                ProcessObject(component, inactiveObjectsShouldBecome);
+            }
+        }
+
+        private static void ProcessObject(Component component, bool shouldBecome)
+        {
+            if (component is Transform) component.gameObject.SetActive(shouldBecome);
+            else if (component is Behaviour behaviour) behaviour.enabled = shouldBecome;
+        }
+
+        public void OnGuidAssigned(int guidIndex, Guid guid)
+        {
+            _featureEvent = featureNetworking.NewEventDriven(guidIndex, OnEventReceived, OnResyncRequested, OnResyncEveryoneRequested);
+        }
+
+        private void OnResyncRequested(ushort[] whoAsked)
+        {
+            _msg[0] = _currentTargetState ? (byte)1 : (byte)0;
+            _featureEvent.Submit(_msg, whoAsked);
+        }
+
+        private void OnResyncEveryoneRequested()
+        {
+            InternalSubmitToEveryone();
+        }
+
+        private void OnAddressUpdated(string receivedAddress, float value)
+        {
+            if (receivedAddress != address) throw new ArgumentException("Unexpected address received");
+
+            var state = value >= 1f;
+            if (_currentTargetState != state)
+            {
+                InternalConfirmedUpdateStateChange(state);
+
+                if (_featureEvent != null)
+                {
+                    InternalSubmitToEveryone();
+                }
+            }
+        }
+
+        private void InternalSubmitToEveryone()
+        {
+            _msg[0] = _currentTargetState ? (byte)1 : (byte)0;
+            _featureEvent.Submit(_msg);
+        }
+
+        private void OnEventReceived(ArraySegment<byte> subBuffer)
+        {
+            if (subBuffer.Count != 1) return; // Protocol error: Unexpected length.
+
+            var item = subBuffer.get_Item(0);
+            if (item > 1) return; // Protocol error: Unexpected value.
+
+            var state = item == 1;
+            if (_currentTargetState != state)
+            {
+                InternalConfirmedUpdateStateChange(state);
+            }
+        }
+
+        private void InternalConfirmedUpdateStateChange(bool state)
+        {
+            if (_lastCoroutineNullable != null)
+            {
+                StopCoroutine(_lastCoroutineNullable);
+                _lastCoroutineNullable = null;
+            }
+            
+            _currentTargetState = state;
+            var nextInterpolationDuration = state ? interpolationToActiveDuration : interpolationToInactiveDuration;
+            
+            if (isInterpolated && nextInterpolationDuration > 0)
+            {
+                _currentInterpolation = InterpolatingState.Interpolating;
+                _lastStateChangeTime = Time.time;
+                _endStateChangeTime = Time.time + nextInterpolationDuration;
+                    
+                ForceUpdateState();
+
+                _lastCoroutineNullable = StartCoroutine(FinishInterpolation());
+            }
+            else
+            {
+                _currentInterpolation = state ? InterpolatingState.Active : InterpolatingState.Inactive;
+                _lastStateChangeTime = Time.time;
+                _endStateChangeTime = Time.time;
+                    
+                ForceUpdateState();
+            }
+        }
+
+        private IEnumerator FinishInterpolation()
+        {
+            var timeToWait = _endStateChangeTime - Time.time;
+            Debug.Log($"Will wait {timeToWait} seconds before switching to {_currentTargetState}");
+            
+            yield return new WaitForSeconds(timeToWait);
+            
+            _currentInterpolation = _currentTargetState ? InterpolatingState.Active : InterpolatingState.Inactive;
+            ForceUpdateState();
+        }
+    }
+
+    public enum ActivationSource
+    {
+        Address
+    }
+
+    internal enum InterpolatingState
+    {
+        Inactive, Active, Interpolating
+    }
+}

--- a/Packages/HVRBasisAvatarComms/Scripts/Actuation/ObjectStateActuation.cs.meta
+++ b/Packages/HVRBasisAvatarComms/Scripts/Actuation/ObjectStateActuation.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 04fdbfa0725d4a9e97a02b2464322be0
+timeCreated: 1734005879

--- a/Packages/HVRBasisAvatarComms/Scripts/Comms.md
+++ b/Packages/HVRBasisAvatarComms/Scripts/Comms.md
@@ -40,7 +40,13 @@ All messages are trickling from the avatar wearer to the other observers.
 
 ### Negotiation packet (\[0\] == 255)
 
-The Negotiation packet must be the very first packet that is transmitted to another client before any other packet of that protocol is transmitted.
+- Who can send: Wearer
+- Who can receive: Non-wearers
+
+The Negotiation packet should be the first packet transmitted to all other clients when the avatar loads.
+
+If a client sends us a Reserved packet of type *Remote Requests Initialization* (described later in this document),
+a Negotiation packet should be sent to them.
 
 This packet defines a sequence of GUIDs. The GUIDs are already uniquely assigned to specific networked systems, as such they serve
 as networked IDs.
@@ -97,6 +103,9 @@ Assert that:
 
 ### Transmission packet (\[0\] < 254)
 
+- Who can send: Wearer
+- Who can receive: Non-wearers
+
 Transmission packets contains the data payload, along with relative timing information that will be used for interpolation.
 
 The data payload specification depends entirely on the implementation.
@@ -106,6 +115,10 @@ The data payload specification depends entirely on the implementation.
 The following applies when `bytes[0]` is strictly less than 255.
 
 The value of `bytes[0]` corresponds to the index of the GUID that represents the component.
+
+The rest of the message depends on whether the packet is being received by a streaming feature or an event-driven feature:
+
+##### Streaming
 
 The value of `bytes[1]` is the interpolation duration needed for this packet.
 - It is generally defined to be the number of seconds since the last packet was sent, multiplied by 60 (a second is quantized in 60 parts).
@@ -120,3 +133,12 @@ Assert that:
 - At least one valid Negotiation packet has been previously received.
 - `bytes[0]` must be less than the `NumberOfGuids` received in the last Negotiation packet.
 - `bytes.Length` must be greater or equal to 2.
+
+##### Event-Driven
+
+The rest of the message is not subject to additional restrictions.
+
+Assert that:
+- `bytes[0]` must be less than the `NumberOfGuids` received in the last Negotiation packet.
+- At least one valid Negotiation packet has been previously received.
+- `bytes.Length` must be greater or equal to 1.

--- a/Packages/HVRBasisAvatarComms/Scripts/CommsUtil.cs
+++ b/Packages/HVRBasisAvatarComms/Scripts/CommsUtil.cs
@@ -1,5 +1,8 @@
-﻿using Basis.Scripts.BasisSdk;
+﻿using System;
+using System.Linq;
+using Basis.Scripts.BasisSdk;
 using UnityEngine;
+using Object = UnityEngine.Object;
 
 namespace HVR.Basis.Comms
 {
@@ -24,6 +27,25 @@ namespace HVR.Basis.Comms
         internal static FeatureNetworking FeatureNetworkingFromAvatar(BasisAvatar avatar)
         {
             return avatar.GetComponentInChildren<FeatureNetworking>(true);
+        }
+
+        /// Semantically used to sanitize a serializable field of objects provided by an End User.<br/>
+        /// Given a nullable array of Unity Objects that may contain null-Destroy Objects,
+        /// return a non-null array of Unity Objects that does not contain null-Destroy Objects.
+        public static T[] SlowSanitizeEndUserProvidedObjectArray<T>(T[] objectsNullable) where T : Object
+        {
+            if (objectsNullable == null) return Array.Empty<T>();
+            
+            return objectsNullable.Where(t => t).ToArray();
+        }
+
+        /// Semantically used to sanitize a serializable field of structs provided by an End User.<br/>
+        /// Returns itself, or an empty array if the parameter is null.
+        public static T[] SlowSanitizeEndUserProvidedStructArray<T>(T[] structuresNullable) where T : struct
+        {
+            if (structuresNullable == null) return Array.Empty<T>();
+            
+            return structuresNullable;
         }
     }
 }

--- a/Packages/HVRBasisAvatarComms/Scripts/Editor/AcquisitionAssistEditor.cs
+++ b/Packages/HVRBasisAvatarComms/Scripts/Editor/AcquisitionAssistEditor.cs
@@ -1,5 +1,6 @@
 ﻿using System.Linq;
 using UnityEditor;
+using UnityEngine;
 
 namespace HVR.Basis.Comms
 {
@@ -11,20 +12,36 @@ namespace HVR.Basis.Comms
             DrawDefaultInspector();
 
             var assist = (AcquisitionAssist)target;
-            var groupings = assist.definitionFile.definitions.GroupBy(definition => definition.address, definition => definition);
-            foreach (var definitions in groupings)
+            if (assist.definitionFile)
             {
-                var address = definitions.First().address;
-                assist.memory.TryGetValue(address, out var value);
-                var allInEnds = definitions.Select(definition => definition.inStart).Concat(definitions.Select(definition => definition.inEnd)).ToArray();
-                var min = allInEnds.Min();
-                var max = allInEnds.Max();
-                var newValue = EditorGUILayout.Slider(address, value, min, max);
-                if (value != newValue)
+                var groupings = assist.definitionFile.definitions.GroupBy(definition => definition.address, definition => definition);
+                foreach (var definitions in groupings)
                 {
-                    assist.memory[address] = newValue;
-                    assist.acquisitionService.Submit(address, newValue);
-                } 
+                    var address = definitions.First().address;
+                    assist.memory.TryGetValue(address, out var value);
+                    var allInEnds = definitions.Select(definition => definition.inStart).Concat(definitions.Select(definition => definition.inEnd)).ToArray();
+                    var min = allInEnds.Min();
+                    var max = allInEnds.Max();
+                    var newValue = EditorGUILayout.Slider(address, value, min, max);
+                    if (value != newValue)
+                    {
+                        assist.memory[address] = newValue;
+                        assist.acquisitionService.Submit(address, newValue);
+                    }
+                }
+            }
+            foreach (var def in assist.toggles)
+            {
+                EditorGUILayout.BeginHorizontal();
+                if (GUILayout.Button($"{def} = false"))
+                {
+                    assist.acquisitionService.Submit(def, 0f);
+                }
+                if (GUILayout.Button($"{def} = true"))
+                {
+                    assist.acquisitionService.Submit(def, 1f);
+                }
+                EditorGUILayout.EndHorizontal();
             }
         }
     }

--- a/Packages/HVRBasisAvatarComms/Scripts/Editor/BlendshapeActuationDefinitionFileEditor.cs
+++ b/Packages/HVRBasisAvatarComms/Scripts/Editor/BlendshapeActuationDefinitionFileEditor.cs
@@ -16,6 +16,7 @@ namespace HVR.Basis.Comms
 
         public override void OnInspectorGUI()
         {
+            EditorGUILayout.LabelField(((BlendshapeActuationDefinitionFile)target).comment ?? "", EditorStyles.wordWrappedLabel);
             DrawDefaultInspector();
 
             EditorGUILayout.BeginHorizontal();

--- a/Packages/HVRBasisAvatarComms/Scripts/FeatureNetworking/FeatureNetworking.cs
+++ b/Packages/HVRBasisAvatarComms/Scripts/FeatureNetworking/FeatureNetworking.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using Basis.Scripts.BasisSdk;
+using DarkRift;
 using UnityEngine;
 
 namespace HVR.Basis.Comms
@@ -11,8 +12,13 @@ namespace HVR.Basis.Comms
     {
         public const byte NegotiationPacket = 255;
         public const byte ReservedPacket = 254;
+        
+        public const byte ReservedPacket_RemoteRequestsInitializationMessage = 0;
 
         public delegate void InterpolatedDataChanged(float[] current);
+        public delegate void EventReceived(ArraySegment<byte> subBuffer);
+        public delegate void ResyncRequested(ushort[] whoAsked);
+        public delegate void ResyncEveryoneRequested();
 
         [SerializeField] private FeatureNetPairing[] netPairings = new FeatureNetPairing[0]; // Unsafe: May contain malformed GUIDs, or null components, or non-networkable components.
         [HideInInspector] [SerializeField] private BasisAvatar avatar;
@@ -21,9 +27,10 @@ namespace HVR.Basis.Comms
         private Guid[] _orderedGuids;
         private byte[] _negotiationPacket;
         
-        private FeatureInterpolator[] _featureHandles;
+        private IFeatureReceiver[] _featureHandles; // May contain null values if the corresponding Feature fails to initialize. Iterate defensively
         private GameObject _holder;
         private bool _isWearer;
+        private byte[] _remoteRequestsInitializationPacket;
 
         private void Awake()
         {
@@ -62,14 +69,15 @@ namespace HVR.Basis.Comms
                 // The order of the list of pairings should not matter between clients because of the Negotiation packet.
                 .OrderBy(_ => rand.Next())
                 .ToArray();
-                
+            
             _guidToNetworkable = safeNetPairings.ToDictionary(pairing => new Guid(pairing.guid), pairing => (ICommsNetworkable)pairing.component);
             _orderedGuids = safeNetPairings.Select(pairing => new Guid(pairing.guid)).ToArray();
             _negotiationPacket = new [] { NegotiationPacket }
                 .Concat(safeNetPairings.SelectMany(pairing => new Guid(pairing.guid).ToByteArray()))
                 .ToArray();
+            _remoteRequestsInitializationPacket = new[] { ReservedPacket, ReservedPacket_RemoteRequestsInitializationMessage };
 
-            _featureHandles = new FeatureInterpolator[safeNetPairings.Length];
+            _featureHandles = new IFeatureReceiver[safeNetPairings.Length];
         }
 
         public void OnPacketReceived(int guidIndex, ArraySegment<byte> arraySegment)
@@ -105,6 +113,13 @@ namespace HVR.Basis.Comms
             return handle;
         }
 
+        public FeatureEvent NewEventDriven(int guidIndex, EventReceived eventReceived, ResyncRequested resyncRequested, ResyncEveryoneRequested resyncEveryoneRequested)
+        {
+            var handle = new FeatureEvent(this, guidIndex, eventReceived, resyncRequested, resyncEveryoneRequested, avatar);
+            _featureHandles[guidIndex] = handle;
+            return handle;
+        }
+
         internal void Unregister(int guidIndex)
         {
             _featureHandles[guidIndex] = null;
@@ -114,6 +129,11 @@ namespace HVR.Basis.Comms
         public byte[] GetNegotiationPacket()
         {
             return _negotiationPacket;
+        }
+
+        public byte[] GetRemoteRequestsInitializationPacket()
+        {
+            return _remoteRequestsInitializationPacket;
         }
 
         public void AssignGuids(bool isWearer)
@@ -145,21 +165,108 @@ namespace HVR.Basis.Comms
 
             return false;
         }
+
+        public void TryResyncEveryone()
+        {
+            foreach (var featureReceiver in _featureHandles)
+            {
+                if (featureReceiver != null)
+                {
+                    featureReceiver.OnResyncEveryoneRequested();
+                }
+            }
+        }
+
+        public void TryResyncSome(ushort[] whoAsked)
+        {
+            foreach (var featureReceiver in _featureHandles)
+            {
+                if (featureReceiver != null)
+                {
+                    featureReceiver.OnResyncRequested(whoAsked);
+                }
+            }
+        }
     }
 
-    public class FeatureInterpolator
+    public class FeatureEvent : IFeatureReceiver
+    {
+        private const DeliveryMethod DeliveryMethod = DarkRift.DeliveryMethod.Sequenced;
+        
+        private readonly FeatureNetworking _featureNetworking;
+        private readonly int _guidIndex;
+        private readonly FeatureNetworking.EventReceived _eventReceived;
+        private readonly FeatureNetworking.ResyncRequested _resyncRequested;
+        private readonly FeatureNetworking.ResyncEveryoneRequested _resyncEveryoneRequested;
+        private readonly BasisAvatar _avatar;
+
+        public FeatureEvent(FeatureNetworking featureNetworking, int guidIndex, FeatureNetworking.EventReceived eventReceived, FeatureNetworking.ResyncRequested resyncRequested, FeatureNetworking.ResyncEveryoneRequested resyncEveryoneRequested, BasisAvatar avatar)
+        {
+            _featureNetworking = featureNetworking;
+            _guidIndex = guidIndex;
+            _eventReceived = eventReceived;
+            _resyncRequested = resyncRequested;
+            _resyncEveryoneRequested = resyncEveryoneRequested;
+            _avatar = avatar;
+        }
+
+        public void Unregister()
+        {
+            _featureNetworking.Unregister(_guidIndex);
+        }
+
+        public void OnPacketReceived(ArraySegment<byte> data)
+        {
+            _eventReceived.Invoke(data);
+        }
+
+        public void OnResyncEveryoneRequested()
+        {
+            _resyncEveryoneRequested.Invoke();
+        }
+
+        public void OnResyncRequested(ushort[] whoAsked)
+        {
+            _resyncRequested.Invoke(whoAsked);
+        }
+
+        public void Submit(ArraySegment<byte> currentState)
+        {
+            SubmitInternal(currentState, null);
+        }
+
+        public void Submit(ArraySegment<byte> currentState, ushort[] whoAsked)
+        {
+            if (whoAsked == null) throw new ArgumentException("whoAsked cannot be null");
+            if (whoAsked.Length == 0) throw new ArgumentException("whoAsked cannot be empty");
+            
+            SubmitInternal(currentState, whoAsked);
+        }
+
+        private void SubmitInternal(ArraySegment<byte> currentState, ushort[] whoAskedNullable)
+        {
+            var buffer = new byte[1 + currentState.Count];
+            buffer[0] = (byte)_guidIndex;
+            
+            currentState.CopyTo(buffer, 1);
+            
+            _avatar.NetworkMessageSend(HVRAvatarComms.OurMessageIndex, buffer, DeliveryMethod, whoAskedNullable);
+        }
+    }
+
+    public class FeatureInterpolator : IFeatureReceiver
     {
         private readonly FeatureNetworking _featureNetworking;
-        private readonly int guidIndex;
+        private readonly int _guidIndex;
         private readonly StreamedAvatarFeature _streamed;
-        private readonly FeatureNetworking.InterpolatedDataChanged interpolatedDataChanged;
+        private readonly FeatureNetworking.InterpolatedDataChanged _interpolatedDataChanged;
 
         internal FeatureInterpolator(FeatureNetworking featureNetworking, int guidIndex, StreamedAvatarFeature streamed, FeatureNetworking.InterpolatedDataChanged interpolatedDataChanged)
         {
             _featureNetworking = featureNetworking;
-            this.guidIndex = guidIndex;
+            _guidIndex = guidIndex;
             _streamed = streamed;
-            this.interpolatedDataChanged = interpolatedDataChanged;
+            _interpolatedDataChanged = interpolatedDataChanged;
         }
 
         public void Store(int value, float streamed01)
@@ -169,7 +276,7 @@ namespace HVR.Basis.Comms
 
         public void Unregister()
         {
-            _featureNetworking.Unregister(guidIndex);
+            _featureNetworking.Unregister(_guidIndex);
         }
 
         public void OnPacketReceived(ArraySegment<byte> data)
@@ -177,9 +284,19 @@ namespace HVR.Basis.Comms
             _streamed.OnPacketReceived(data);
         }
 
+        public void OnResyncEveryoneRequested()
+        {
+            _streamed.OnResyncEveryoneRequested();
+        }
+
+        public void OnResyncRequested(ushort[] whoAsked)
+        {
+            _streamed.OnResyncRequested(whoAsked);
+        }
+
         public void OnInterpolatedDataChanged(float[] current)
         {
-            interpolatedDataChanged.Invoke(current);
+            _interpolatedDataChanged.Invoke(current);
         }
     }
 
@@ -188,5 +305,12 @@ namespace HVR.Basis.Comms
     {
         public Component component;
         public string guid;
+    }
+
+    public class RequestedFeature
+    {
+        public string identifier;
+        public float lower;
+        public float upper;
     }
 }

--- a/Packages/HVRBasisAvatarComms/Scripts/FeatureNetworking/IFeatureReceiver.cs
+++ b/Packages/HVRBasisAvatarComms/Scripts/FeatureNetworking/IFeatureReceiver.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace HVR.Basis.Comms
+{
+    public interface IFeatureReceiver
+    {
+        void OnPacketReceived(ArraySegment<byte> data);
+        void OnResyncEveryoneRequested();
+        void OnResyncRequested(ushort[] whoAsked);
+    }
+}

--- a/Packages/HVRBasisAvatarComms/Scripts/FeatureNetworking/IFeatureReceiver.cs.meta
+++ b/Packages/HVRBasisAvatarComms/Scripts/FeatureNetworking/IFeatureReceiver.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: e6a7d8cb54d04409bb6cc24931ffdaff
+timeCreated: 1734025033

--- a/Packages/HVRBasisAvatarComms/Scripts/HVRAvatarComms.cs
+++ b/Packages/HVRBasisAvatarComms/Scripts/HVRAvatarComms.cs
@@ -1,16 +1,18 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using Basis.Scripts.BasisSdk;
 using DarkRift;
 using UnityEngine;
+using Debug = UnityEngine.Debug;
 
 namespace HVR.Basis.Comms
 {
     [AddComponentMenu("HVR.Basis/Comms/Internal/Avatar Comms")]
     public class HVRAvatarComms : MonoBehaviour
     {
+        // Use Sequenced, because we know this delivery type works
+        private const DeliveryMethod MainMessageDeliveryMethod = DeliveryMethod.Sequenced;
         private const DeliveryMethod NegotiationDelivery = DeliveryMethod.ReliableOrdered;
         
         public const byte OurMessageIndex = 0xC0;
@@ -21,9 +23,10 @@ namespace HVR.Basis.Comms
         
         private bool _isWearer;
         private ushort _wearerNetId;
+        private ushort[] _wearerNetIdRecipient;
         private Guid[] _negotiatedGuids;
         private Dictionary<int, int> _fromTheirsToOurs;
-        private Stopwatch _debugRetrySendNegotiation;
+        // private Stopwatch _debugRetrySendNegotiation;
         private bool _alreadyInitialized;
 
         private void Awake()
@@ -35,6 +38,7 @@ namespace HVR.Basis.Comms
                 throw new InvalidOperationException("Broke assumption: Avatar and/or FeatureNetworking cannot be found.");
             }
             
+            avatar.OnAvatarNetworkReady -= OnAvatarNetworkReady;
             avatar.OnAvatarNetworkReady += OnAvatarNetworkReady;
         }
 
@@ -50,61 +54,74 @@ namespace HVR.Basis.Comms
             
             _isWearer = avatar.IsOwnedLocally;
             _wearerNetId = avatar.LinkedPlayerID;
+            _wearerNetIdRecipient = new[] { _wearerNetId };
 
             featureNetworking.AssignGuids(_isWearer);
 
             avatar.OnNetworkMessageReceived += OnNetworkMessageReceived;
             if (_isWearer)
             {
-                _debugRetrySendNegotiation = new Stopwatch();
-                _debugRetrySendNegotiation.Restart();
+                // _debugRetrySendNegotiation = new Stopwatch();
+                // _debugRetrySendNegotiation.Restart();
+                
+                // Initialize other users.
+                Debug.Log($"Sending Negotiation Packet to everyone...");
+                avatar.NetworkMessageSend(OurMessageIndex, featureNetworking.GetNegotiationPacket(), MainMessageDeliveryMethod);
+                featureNetworking.TryResyncEveryone();
+            }
+            else
+            {
+                Debug.Log($"Sending ReservedPacket_RemoteRequestsInitializationMessage to {_wearerNetId}...");
+                // Handle late-joining, or loading the avatar after the wearer does. Ask the wearer to initialize us.
+                // - If the wearer has not finished loading their own avatar, they will initialize us anyways.
+                avatar.NetworkMessageSend(OurMessageIndex, featureNetworking.GetRemoteRequestsInitializationPacket(), MainMessageDeliveryMethod, _wearerNetIdRecipient);
             }
         }
 
         private void Update()
         {
-            if (!_isWearer) return;
-
-            // This is a hack: Send the negotiation packet every so often, because the negotiation packets are currently not going through properly.
-            if (_debugRetrySendNegotiation.ElapsedMilliseconds > 5000)
-            {
-                _debugRetrySendNegotiation.Restart();
-                avatar.NetworkMessageSend(OurMessageIndex, featureNetworking.GetNegotiationPacket(), DeliveryMethod.Sequenced); // Use Sequenced, because we know this delivery type works
-            }
+            // if (!_isWearer) return;
+            //
+            // // This is a hack: Send the negotiation packet every so often, because the negotiation packets are currently not going through properly.
+            // if (_debugRetrySendNegotiation.ElapsedMilliseconds > 5000)
+            // {
+            //     _debugRetrySendNegotiation.Restart();
+            //     avatar.NetworkMessageSend(OurMessageIndex, featureNetworking.GetNegotiationPacket(), MainMessageDeliveryMethod);
+            // }
         }
 
-        private void OnNetworkMessageReceived(ushort playerid, byte messageindex, byte[] unsafeBuffer, ushort[] recipients)
+        private void OnNetworkMessageReceived(ushort whoSentThis, byte messageindex, byte[] unsafeBuffer, ushort[] recipients)
         {
             // Ignore all other messages first
             if (OurMessageIndex != messageindex) return;
             
             // Ignore all net messages as long as this is disabled
             if (!isActiveAndEnabled) return;
-            
-            // The sender cannot receive
-            if (_isWearer) return;
 
             if (unsafeBuffer.Length == 0) return; // Protocol error: Missing sub-packet identifier
             
-            var isSentByWearer = _wearerNetId == playerid;
+            var isSentByWearer = _wearerNetId == whoSentThis;
             
             var theirs = unsafeBuffer[0];
             if (theirs == FeatureNetworking.NegotiationPacket)
             {
-                // Only the wearer can send us this message
-                if (!isSentByWearer) return;
+                if (!isSentByWearer) return; // Protocol error: Only the wearer can send us this message.
+                if (_isWearer) return; // Protocol error: The wearer cannot receive this message.
                 
+                Debug.Log($"Receiving Negotiation packet from {whoSentThis}...");
                 DecodeNegotiationPacket(SubBuffer(unsafeBuffer));
             }
             else if (theirs == FeatureNetworking.ReservedPacket)
             {
+                Debug.Log($"Decoding reserved packet...");
+                
                 // Reserved packets are not necessarily sent by the wearer.
-                DecodeReservedPacket(SubBuffer(unsafeBuffer));
+                DecodeReservedPacket(SubBuffer(unsafeBuffer), whoSentThis, isSentByWearer);
             }
             else // Transmission packet
             {
-                // Only the wearer can send us this message
-                if (!isSentByWearer) return;
+                if (!isSentByWearer) return; // Protocol error: Only the wearer can send us this message.
+                if (_isWearer) return; // Protocol error: The wearer cannot receive this message.
                 
                 if (_fromTheirsToOurs == null) return; // Protocol error: No valid Networking packet was previously received
                 
@@ -128,7 +145,7 @@ namespace HVR.Basis.Comms
 
         private bool DecodeNegotiationPacket(ArraySegment<byte> unsafeGuids)
         {
-            if (unsafeGuids.Count % BytesPerGuid != 0) return false;
+            if (unsafeGuids.Count % BytesPerGuid != 0) return false; // Protocol error: Unexpected message length.
             
             // Safe after this point
             var safeGuids = unsafeGuids;
@@ -162,13 +179,28 @@ namespace HVR.Basis.Comms
             return true;
         }
 
-        private void DecodeReservedPacket(ArraySegment<byte> data)
+        private void DecodeReservedPacket(ArraySegment<byte> data, ushort whoSentThis, bool isSentByWearer)
         {
             if (data.Count == 0) return; // Protocol error: Missing data identifier
 
             var reservedPacketIdentifier = data.get_Item(0);
 
-            // Reserved packets are not currently used.
+            if (reservedPacketIdentifier == FeatureNetworking.ReservedPacket_RemoteRequestsInitializationMessage)
+            {
+                if (isSentByWearer) return; // Protocol error: Only remote users can send this message.
+                if (!_isWearer) return; // Protocol error: Only the wearer can receive this message.
+                if (data.Count != 1) return; // Protocol error: Unexpected message length.
+                
+                // TODO: We need a way to ignore incoming initialization requests if the avatar isn't the correct one
+                
+                Debug.Log($"Valid ReservedPacket_RemoteRequestsInitializationMessage received, sending negotiation packet now to {whoSentThis}...");
+                avatar.NetworkMessageSend(OurMessageIndex, featureNetworking.GetNegotiationPacket(), MainMessageDeliveryMethod, new[] { whoSentThis });
+                featureNetworking.TryResyncSome(new [] { whoSentThis });
+            }
+            else
+            {
+                // Protocol error: This reserved packet is not known. 
+            }
         }
     }
 }


### PR DESCRIPTION
- Work towards adding Toggles:
  - Add Object State Actuation component.
  - Toggling from OFF to ON sends a packet.
  - Toggling from ON to OFF sends a packet.
  - Late joining / Late loading: When a remote player loads the avatar, it asks the avatar wearer to send the state of the toggle to them.
  - Early loading: If a remote player loads the avatar faster than the wearer, the wearer will send the state of the toggle when the wearer finishes loading.
  - Unlike face tracking, this is not a continuous stream of data, so no packets are sent continuously if the toggle remains untouched.
- Improve late loading and early loading in the HVRAvatarComms protocol:
  - When a non-wearer finishes loading the avatar networking, a Reserved packet of type "Remote Requests Initialization" is sent to the wearer, so that the wearer sends a Negotiation packet to them.
  - When the wearer finishes loading the avatar networking, a Negotiation packet is sent to everyone else.
  - Remove periodic Negotiation packet, which was a hack for which the aforementioned changes replace.
- Null values are removed from user-provided arrays (i.e. in BlendshapeActuation).
- Support resyncing in features:
  - When after a Negotiation packet is sent, the wearer also asks the features to submit packets for resyncing state.
- AcquisitionAssist can now feed data with values 0 and 1, presented as buttons to test toggles.